### PR TITLE
Add SSL passthrough annotation to NGINX

### DIFF
--- a/pkg/controller/siddhiprocess/ingress.go
+++ b/pkg/controller/siddhiprocess/ingress.go
@@ -108,6 +108,7 @@ func (reconcileSiddhiProcess *ReconcileSiddhiProcess) loadBalancerForSiddhiProce
 			Annotations: map[string]string{
 				"kubernetes.io/ingress.class": "nginx",
 				"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
 			},
 		},
 		Spec: ingressSpec,


### PR DESCRIPTION
## Purpose
> Enable SSL passthrough

## Approach
> Add SSL passthrough annotation to NGINX.

## Test environment
> minikube version: v0.33.1
