### PR TITLE
Remove return of the status updation error

### DIFF
--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -148,7 +148,6 @@ func (reconcileSiddhiProcess *ReconcileSiddhiProcess) Reconcile(request reconcil
 		if err != nil {
 			reqLogger.Error(err, "Failed to update SiddhiProcess status")
 			siddhiProcess.Status.Status = getStatus(ERROR)
-			return reconcile.Result{}, err
 		}
 		siddhiDeployment, err := reconcileSiddhiProcess.deploymentForSiddhiProcess(siddhiProcess, siddhiApp, operatorEnvs)
 		if err != nil{
@@ -203,7 +202,6 @@ func (reconcileSiddhiProcess *ReconcileSiddhiProcess) Reconcile(request reconcil
 		if err != nil {
 			reqLogger.Error(err, "Failed to update SiddhiProcess status")
 			siddhiProcess.Status.Status = getStatus(ERROR)
-			return reconcile.Result{}, err
 		}
 		return reconcile.Result{Requeue: true}, nil
 	} else if err != nil {
@@ -264,7 +262,6 @@ func (reconcileSiddhiProcess *ReconcileSiddhiProcess) Reconcile(request reconcil
 		err := reconcileSiddhiProcess.client.Status().Update(context.TODO(), siddhiProcess)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update SiddhiProcess status")
-			return reconcile.Result{}, err
 		}
 	}
 	return reconcile.Result{}, err


### PR DESCRIPTION
## Purpose
> Resolve #10

## Goals
> To work on Docker for Mac Version 2.0.0.3

## Approach
> When the status update throws an error reconcile loop return and stop the rest of the execution. But it is an unnecessary termination because update status is a low priority task. Here I removed that unnecessary return.

## Test environment
> minikube version: v0.33.1 (kubernetes version v1.10.11 and v1.13.2)
> docker for mac Version 2.0.0.3 (kubernetes version v1.10.11)