### PR TITLE
Add watch for used K8s resources in the operator

### DIFF
--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -97,6 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource Deployments and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -105,6 +106,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource Services and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -113,6 +115,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource PersistentVolumeClaims and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -121,6 +124,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource NatsClusters and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &natsv1alpha2.NatsCluster{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -129,6 +133,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource NatsStreamingClusters and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &streamingv1alpha1.NatsStreamingCluster{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -137,6 +142,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to secondary resource Pods and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -21,7 +21,10 @@ package siddhiprocess
 import (
 	"context"
 
+	natsv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/nats/v1alpha2"
 	siddhiv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/siddhi/v1alpha2"
+	streamingv1alpha1 "github.com/siddhi-io/siddhi-operator/pkg/apis/streaming/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
@@ -94,7 +97,46 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to secondary resource Pods and requeue the owner SiddhiProcess
+	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &natsv1alpha2.NatsCluster{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(&source.Kind{Type: &streamingv1alpha1.NatsStreamingCluster{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
+	})
+	if err != nil {
+		return err
+	}
+
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
@@ -120,7 +162,7 @@ type ReconcileSiddhiProcess struct {
 // and what is in the SiddhiProcess.Spec
 func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling SiddhiProcess")
+	reqLogger.V(1).Info("Reconciling SiddhiProcess")
 
 	sp := &siddhiv1alpha2.SiddhiProcess{}
 	err := rsp.client.Get(context.TODO(), request.NamespacedName, sp)


### PR DESCRIPTION
## Purpose
> Resolve the issue https://github.com/siddhi-io/siddhi-operator/issues/39

## Approach
> Add watch functions to each resource that used inside the siddhi-operator. Also made the initial reconcile loop log into the debug mode log.

## Test environment
> minikube version: v0.33.1 and GKE