### PR TITLE
Enable rolling update and resolve ingress multihost issue

### DIFF
--- a/pkg/controller/siddhiprocess/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifacts_test.go
@@ -94,7 +94,7 @@ func TestCreateAndUpdateIngress(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(ingress.Spec.Rules) != 2 {
+	if len(ingress.Spec.Rules[0].HTTP.Paths) != 2 {
 		t.Error("Ingress update error. Expected entries 2, but found " + strconv.Itoa(len(ingress.Spec.Rules)))
 	}
 }
@@ -197,6 +197,7 @@ func TestCreateDeployment(t *testing.T) {
 		corev1.PullAlways,
 		[]corev1.LocalObjectReference{},
 		[]corev1.Volume{},
+		appsv1.DeploymentStrategy{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -76,6 +76,8 @@ const (
 	NATSTimeout        int    = 5
 	DefaultRTime       int    = 1
 	DeploymentSize     int32  = 1
+	MaxUnavailable     int32  = 0
+	MaxSurge           int32  = 2
 )
 
 // State persistence config is the different string constant used by the deployApp() function. This constant holds a YAML object
@@ -178,6 +180,8 @@ type Configs struct {
 	NATSTimeout        int
 	DefaultRTime       int
 	DeploymentSize     int32
+	MaxUnavailable     int32
+	MaxSurge           int32
 }
 
 // SPConfig contains the state persistence configs
@@ -388,6 +392,8 @@ func (rsp *ReconcileSiddhiProcess) Configurations(sp *siddhiv1alpha2.SiddhiProce
 		NATSTimeout:        NATSTimeout,
 		DefaultRTime:       DefaultRTime,
 		DeploymentSize:     DeploymentSize,
+		MaxUnavailable:     MaxUnavailable,
+		MaxSurge:           MaxSurge,
 	}
 	cmName := OperatorCMName
 	env := os.Getenv("OPERATOR_CONFIGMAP")

--- a/pkg/controller/siddhiprocess/utils.go
+++ b/pkg/controller/siddhiprocess/utils.go
@@ -23,12 +23,14 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 
 	siddhiv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/siddhi/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 
 	"gopkg.in/yaml.v2"
 	"path/filepath"
@@ -210,4 +212,14 @@ func createPVCVolumes(pvcName string, mountPath string) (volume corev1.Volume, v
 		MountPath: mountPath,
 	}
 	return
+}
+
+// pathContains checks the given path is available on ingress path lists or not
+func pathContains(paths []extensionsv1beta1.HTTPIngressPath, path extensionsv1beta1.HTTPIngressPath) bool {
+	for _, p := range paths {
+		if reflect.DeepEqual(p, path) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/siddhiprocess/utils_test.go
+++ b/pkg/controller/siddhiprocess/utils_test.go
@@ -23,8 +23,10 @@ import (
 
 	siddhiv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/siddhi/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -138,6 +140,58 @@ func TestCreatePVCVolumes(t *testing.T) {
 	}
 	if volumeMount.MountPath != mountPath {
 		t.Error("Expected volume mount name " + mountPath + " but found " + volumeMount.MountPath)
+	}
+}
+
+func TestPathContains(t *testing.T) {
+	paths := []extensionsv1beta1.HTTPIngressPath{
+		extensionsv1beta1.HTTPIngressPath{
+			Path: "/app1/8080/example",
+			Backend: extensionsv1beta1.IngressBackend{
+				ServiceName: "app1",
+				ServicePort: intstr.IntOrString{
+					Type:   Int,
+					IntVal: 8080,
+				},
+			},
+		},
+		extensionsv1beta1.HTTPIngressPath{
+			Path: "/app2/8080/example",
+			Backend: extensionsv1beta1.IngressBackend{
+				ServiceName: "app2",
+				ServicePort: intstr.IntOrString{
+					Type:   Int,
+					IntVal: 8080,
+				},
+			},
+		},
+	}
+	negativePath := extensionsv1beta1.HTTPIngressPath{
+		Path: "/app3/8080/example",
+		Backend: extensionsv1beta1.IngressBackend{
+			ServiceName: "app3",
+			ServicePort: intstr.IntOrString{
+				Type:   Int,
+				IntVal: 8080,
+			},
+		},
+	}
+	positivePath := extensionsv1beta1.HTTPIngressPath{
+		Path: "/app2/8080/example",
+		Backend: extensionsv1beta1.IngressBackend{
+			ServiceName: "app2",
+			ServicePort: intstr.IntOrString{
+				Type:   Int,
+				IntVal: 8080,
+			},
+		},
+	}
+
+	if pathContains(paths, negativePath) {
+		t.Error("Expected value pathContains=false but found true")
+	}
+	if !pathContains(paths, positivePath) {
+		t.Error("Expected value pathContains=true but found false")
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Enable rolling updates to stateless apps and resolve #43.

## Approach
### Enable rolling updates
> Check whether the given app is stateless or not. If that app is stateless then support rolling update with MaxUnavailable=0 and MaxSurge=2 #42. 

### Resolve #43 
> If hostname available in the ingress then add HTTP paths to that specific rule instead of appending a new rule.

## Automation tests
 - Unit tests 
   > Add unit test to the new `pathContains` function.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> minikube version: v0.33.1
 