### PR TITLE
Resolve operator crash when NATS unavailable

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,14 +55,9 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
-    deployment.kubernetes.io/revision: "1"
-  generation: 1
   name: siddhi-parser
 spec:
-  progressDeadlineSeconds: 600
   replicas: 1
-  revisionHistoryLimit: 10
   selector:
     matchLabels:
       name: siddhi-parser
@@ -74,7 +69,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         name: siddhi-parser
         version: 0.2.0-m1

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -125,22 +125,16 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to secondary resource NatsClusters and requeue the owner SiddhiProcess
-	err = c.Watch(&source.Kind{Type: &natsv1alpha2.NatsCluster{}}, &handler.EnqueueRequestForOwner{
+	_ = c.Watch(&source.Kind{Type: &natsv1alpha2.NatsCluster{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
 	})
-	if err != nil {
-		return err
-	}
 
 	// Watch for changes to secondary resource NatsStreamingClusters and requeue the owner SiddhiProcess
-	err = c.Watch(&source.Kind{Type: &streamingv1alpha1.NatsStreamingCluster{}}, &handler.EnqueueRequestForOwner{
+	_ = c.Watch(&source.Kind{Type: &streamingv1alpha1.NatsStreamingCluster{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
 	})
-	if err != nil {
-		return err
-	}
 
 	// Watch for changes to secondary resource Pods and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{

--- a/pkg/controller/siddhiprocess/utils.go
+++ b/pkg/controller/siddhiprocess/utils.go
@@ -129,7 +129,7 @@ func invokeParser(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		err = errors.New(url + " invalid HTTP response status " + strconv.Itoa(http.StatusOK))
+		err = errors.New(url + " invalid HTTP response status " + strconv.Itoa(resp.StatusCode))
 		return
 	}
 	err = json.NewDecoder(resp.Body).Decode(&siddhiAppConfigs)


### PR DESCRIPTION
## Purpose
> Resolve #50. As minor changes resolve HTTP status code showing and remove unwanted specs in parser YAML.

## Approach
> The error throw of the watch function ignored instead of returning it. Do not use any error logging or notification since in the controller runtime by default shows the error. Here we resolve the operator crashing problem. But the operator will show the error of missing NATS because that error log is not in the operator scope.

## Test environment
> minikube 0.33.1
