### PR TITLE
 Enable support for nginx 0.22.0+ versions

### DIFF
--- a/deploy/crds/examples/example-stateful-log-app.yaml
+++ b/deploy/crds/examples/example-stateful-log-app.yaml
@@ -45,10 +45,10 @@ spec:
   
   messagingSystem:
     type: nats
-    config: 
-      bootstrapServers: 
-        - "nats://nats-siddhi:4222"
-      clusterID: stan-siddhi
+    # config: 
+    #   bootstrapServers: 
+    #     - "nats://nats-siddhi:4222"
+    #   clusterID: stan-siddhi
   
   persistentVolume: 
     accessModes: 

--- a/pkg/controller/siddhiprocess/artifacts.go
+++ b/pkg/controller/siddhiprocess/artifacts.go
@@ -76,7 +76,7 @@ func (rsp *ReconcileSiddhiProcess) CreateIngress(
 
 	var ingressPaths []extensionsv1beta1.HTTPIngressPath
 	for _, port := range siddhiApp.ContainerPorts {
-		path := "/" + strings.ToLower(siddhiApp.Name) + "/" + strconv.Itoa(int(port.ContainerPort)) + "/"
+		path := "/" + strings.ToLower(siddhiApp.Name) + "/" + strconv.Itoa(int(port.ContainerPort)) + "(/|$)(.*)"
 		ingressPath := extensionsv1beta1.HTTPIngressPath{
 			Path: path,
 			Backend: extensionsv1beta1.IngressBackend{
@@ -132,9 +132,8 @@ func (rsp *ReconcileSiddhiProcess) CreateIngress(
 			Name:      configs.HostName,
 			Namespace: sp.Namespace,
 			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":                 "nginx",
-				"nginx.ingress.kubernetes.io/rewrite-target":  "/",
-				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+				"kubernetes.io/ingress.class":                "nginx",
+				"nginx.ingress.kubernetes.io/rewrite-target": "/$2",
 			},
 		},
 		Spec: ingressSpec,
@@ -153,7 +152,7 @@ func (rsp *ReconcileSiddhiProcess) UpdateIngress(
 
 	var ingressPaths []extensionsv1beta1.HTTPIngressPath
 	for _, port := range siddhiApp.ContainerPorts {
-		path := "/" + strings.ToLower(siddhiApp.Name) + "/" + strconv.Itoa(int(port.ContainerPort)) + "/"
+		path := "/" + strings.ToLower(siddhiApp.Name) + "/" + strconv.Itoa(int(port.ContainerPort)) + "(/|$)(.*)"
 		ingressPath := extensionsv1beta1.HTTPIngressPath{
 			Path: path,
 			Backend: extensionsv1beta1.IngressBackend{

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -73,7 +73,7 @@ const (
 	IngressTLS                 string = ""
 	HealthPortName             string = "hport"
 	HealthPath                 string = "/health"
-	AutoCreateIngress          bool   = false
+	AutoCreateIngress          bool   = true
 	NATSSize                   int    = 1
 	NATSTimeout                int    = 5
 	DefaultRTime               int    = 1
@@ -121,7 +121,7 @@ const (
 	Distributed    string = "distributed"
 	ProcessApp     string = "process"
 	PassthroughApp string = "passthrough"
-	OperatorCMName string = "siddhi-operator"
+	OperatorCMName string = "siddhi-operator-config"
 )
 
 // Int - Type


### PR DESCRIPTION
## Purpose
> Resolve #53 

## Approach
> The problem occurs due to a change that happened in the [0.22.0 release](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0).  According to their [doc](https://kubernetes.github.io/ingress-nginx/examples/rewrite/#rewrite-target), we have to change the rewrite-target annotation as below to compatible with 0.22.0+ versions.
```yaml
nginx.ingress.kubernetes.io/rewrite-target: /
```
to

```yaml
nginx.ingress.kubernetes.io/rewrite-target: /$2
```
And add this `"(/|$)(.*)"` config to the path.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
-  https://kubernetes.github.io/ingress-nginx/examples/rewrite/#rewrite-target
- https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0

## Test environment
- minikube version: v1.2.0
- nginx controller 0.23.0