### PR TITLE
Change directory paths to be compatible with the streaming integrator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5,8 +5,9 @@ kind: ConfigMap
 metadata:
   name: siddhi-operator-config
 data:
-  siddhiRunnerHome: /home/siddhi_user/siddhi-runner/
-  siddhiRunnerImage: siddhiio/siddhi-runner-alpine:5.1.0-m1
+  siddhiHome: /home/siddhi_user/siddhi-runner/
+  siddhiProfile: runner
+  siddhiImage: siddhiio/siddhi-runner-alpine:5.1.0-m1
   autoIngressCreation: "true"
   # ingressTLS: siddhi-tls
 ---

--- a/pkg/controller/siddhiprocess/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifacts_test.go
@@ -189,7 +189,7 @@ func TestCreateDeployment(t *testing.T) {
 		configs.SiddhiImage,
 		"siddhirunner",
 		[]string{configs.Shell},
-		[]string{configs.SiddhiHome + configs.RunnerRPath},
+		[]string{configs.SiddhiHome + configs.SiddhiBin + "/" + configs.SiddhiProfile + ".sh"},
 		testSiddhiApp.ContainerPorts,
 		[]corev1.VolumeMount{},
 		[]corev1.EnvVar{},

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -81,8 +81,8 @@ const (
 	MaxUnavailable             int32  = 0
 	MaxSurge                   int32  = 2
 	HealthPort                 int32  = 9090
-	ReadyPrPeriodSeconds       int32  = 20
-	ReadyPrInitialDelaySeconds int32  = 40
+	ReadyPrPeriodSeconds       int32  = 5
+	ReadyPrInitialDelaySeconds int32  = 5
 	LivePrPeriodSeconds        int32  = 120
 	LivePrInitialDelaySeconds  int32  = 120
 )

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -81,10 +81,10 @@ const (
 	MaxUnavailable             int32  = 0
 	MaxSurge                   int32  = 2
 	HealthPort                 int32  = 9090
-	ReadyPrPeriodSeconds       int32  = 5
-	ReadyPrInitialDelaySeconds int32  = 5
-	LivePrPeriodSeconds        int32  = 120
-	LivePrInitialDelaySeconds  int32  = 120
+	ReadyPrPeriodSeconds       int32  = 10
+	ReadyPrInitialDelaySeconds int32  = 10
+	LivePrPeriodSeconds        int32  = 70
+	LivePrInitialDelaySeconds  int32  = 20
 )
 
 // State persistence config is the different string constant used by the deployApp() function. This constant holds a YAML object

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -34,18 +34,17 @@ import (
 const (
 	SiddhiHome                 string = "/home/siddhi_user/siddhi-runner/"
 	SiddhiImage                string = "siddhiio/siddhi-runner-alpine:5.1.0-m1"
-	SiddhiRunnerPath           string = "wso2/runner/"
+	SiddhiProfile              string = "runner"
 	SiddhiCMExt                string = "-siddhi"
 	SiddhiExt                  string = ".siddhi"
-	SiddhiFileRPath            string = "siddhi-files/"
+	SiddhiFilesDir             string = "siddhi-files/"
 	ContainerName              string = "siddhi-runner-runtime"
-	DepConfigName              string = "deploymentconfig"
 	DepConfMountPath           string = "tmp/configs/"
 	DepConfParameter           string = "-Dconfig="
 	AppConfParameter           string = "-Dapps="
 	DepCMExt                   string = "-depyml"
 	Shell                      string = "sh"
-	RunnerRPath                string = "bin/runner.sh"
+	SiddhiBin                  string = "bin"
 	HostName                   string = "siddhi"
 	OperatorName               string = "siddhi-operator"
 	OperatorVersion            string = "0.2.0-m1"
@@ -54,7 +53,8 @@ const (
 	ReadOnlyMany               string = "ReadOnlyMany"
 	ReadWriteMany              string = "ReadWriteMany"
 	PVCExt                     string = "-pvc"
-	FilePersistentPath         string = "wso2/runner/siddhi-app-persistence"
+	FilePersistentDir          string = "siddhi-app-persistence"
+	WSO2Dir                    string = "wso2"
 	ParserDomain               string = "http://siddhi-parser."
 	ParserContext              string = ".svc.cluster.local:9090/siddhi-parser/parse"
 	PVCSize                    string = "1Gi"
@@ -82,7 +82,7 @@ const (
 	MaxSurge                   int32  = 2
 	HealthPort                 int32  = 9090
 	ReadyPrPeriodSeconds       int32  = 20
-	ReadyPrInitialDelaySeconds int32  = 60
+	ReadyPrInitialDelaySeconds int32  = 40
 	LivePrPeriodSeconds        int32  = 120
 	LivePrInitialDelaySeconds  int32  = 120
 )
@@ -147,16 +147,15 @@ type Configs struct {
 	SiddhiImageSecret          string
 	SiddhiCMExt                string
 	SiddhiExt                  string
-	SiddhiFileRPath            string
-	SiddhiRunnerPath           string
+	SiddhiFilesDir             string
+	SiddhiProfile              string
 	ContainerName              string
-	DepConfigName              string
 	DepConfMountPath           string
 	DepConfParameter           string
 	AppConfParameter           string
 	DepCMExt                   string
 	Shell                      string
-	RunnerRPath                string
+	SiddhiBin                  string
 	HostName                   string
 	OperatorName               string
 	OperatorVersion            string
@@ -165,7 +164,8 @@ type Configs struct {
 	ReadOnlyMany               string
 	ReadWriteMany              string
 	PVCExt                     string
-	FilePersistentPath         string
+	FilePersistentDir          string
+	WSO2Dir                    string
 	ParserDomain               string
 	ParserContext              string
 	PVCSize                    string
@@ -366,16 +366,15 @@ func (rsp *ReconcileSiddhiProcess) Configurations(sp *siddhiv1alpha2.SiddhiProce
 		SiddhiImage:                SiddhiImage,
 		SiddhiCMExt:                SiddhiCMExt,
 		SiddhiExt:                  SiddhiExt,
-		SiddhiFileRPath:            SiddhiFileRPath,
-		SiddhiRunnerPath:           SiddhiRunnerPath,
+		SiddhiFilesDir:             SiddhiFilesDir,
+		SiddhiProfile:              SiddhiProfile,
 		ContainerName:              ContainerName,
-		DepConfigName:              DepConfigName,
 		DepConfMountPath:           DepConfMountPath,
 		DepConfParameter:           DepConfParameter,
 		AppConfParameter:           AppConfParameter,
 		DepCMExt:                   DepCMExt,
 		Shell:                      Shell,
-		RunnerRPath:                RunnerRPath,
+		SiddhiBin:                  SiddhiBin,
 		HostName:                   HostName,
 		OperatorName:               OperatorName,
 		OperatorVersion:            OperatorVersion,
@@ -384,7 +383,8 @@ func (rsp *ReconcileSiddhiProcess) Configurations(sp *siddhiv1alpha2.SiddhiProce
 		ReadOnlyMany:               ReadOnlyMany,
 		ReadWriteMany:              ReadWriteMany,
 		PVCExt:                     PVCExt,
-		FilePersistentPath:         FilePersistentPath,
+		FilePersistentDir:          FilePersistentDir,
+		WSO2Dir:                    WSO2Dir,
 		ParserDomain:               ParserDomain,
 		ParserContext:              ParserContext,
 		PVCSize:                    PVCSize,
@@ -423,16 +423,20 @@ func (rsp *ReconcileSiddhiProcess) Configurations(sp *siddhiv1alpha2.SiddhiProce
 	configMap := &corev1.ConfigMap{}
 	err := rsp.client.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: sp.Namespace}, configMap)
 	if err == nil {
-		if configMap.Data["siddhiRunnerHome"] != "" {
-			configs.SiddhiHome = configMap.Data["siddhiRunnerHome"]
+		if configMap.Data["siddhiHome"] != "" {
+			configs.SiddhiHome = configMap.Data["siddhiHome"]
 		}
 
-		if configMap.Data["siddhiRunnerImage"] != "" {
-			configs.SiddhiImage = configMap.Data["siddhiRunnerImage"]
+		if configMap.Data["siddhiImage"] != "" {
+			configs.SiddhiImage = configMap.Data["siddhiImage"]
 		}
 
-		if configMap.Data["siddhiRunnerImageSecret"] != "" {
-			configs.SiddhiImageSecret = configMap.Data["siddhiRunnerImageSecret"]
+		if configMap.Data["siddhiImageSecret"] != "" {
+			configs.SiddhiImageSecret = configMap.Data["siddhiImageSecret"]
+		}
+
+		if configMap.Data["siddhiProfile"] != "" {
+			configs.SiddhiProfile = configMap.Data["siddhiProfile"]
 		}
 
 		if configMap.Data["autoIngressCreation"] != "" {

--- a/pkg/controller/siddhiprocess/operator.go
+++ b/pkg/controller/siddhiprocess/operator.go
@@ -134,7 +134,7 @@ func (rsp *ReconcileSiddhiProcess) deployApp(
 	if err != nil {
 		return err
 	}
-	siddhiFilesPath := configs.SiddhiHome + configs.SiddhiFileRPath
+	siddhiFilesPath := configs.SiddhiHome + configs.SiddhiFilesDir
 	volume, volumeMount := createCMVolumes(configMapName, siddhiFilesPath)
 	volumes = append(volumes, volume)
 	volumeMounts = append(volumeMounts, volumeMount)
@@ -149,7 +149,11 @@ func (rsp *ReconcileSiddhiProcess) deployApp(
 		siddhiRunnerImage,
 		configs.ContainerName,
 		[]string{configs.Shell},
-		[]string{siddhiHome + configs.RunnerRPath, siddhiFilesParameter, configParameter},
+		[]string{
+			siddhiHome + configs.SiddhiBin + "/" + configs.SiddhiProfile + ".sh",
+			siddhiFilesParameter,
+			configParameter,
+		},
 		containerPorts,
 		volumeMounts,
 		sp.Spec.Container.Env,

--- a/pkg/controller/siddhiprocess/utils.go
+++ b/pkg/controller/siddhiprocess/utils.go
@@ -169,11 +169,11 @@ func populateMountPath(sp *siddhiv1alpha2.SiddhiProcess, configs Configs) (mount
 	if err != nil {
 		return
 	}
-	mountPath = configs.SiddhiHome + configs.FilePersistentPath
+	mountPath = configs.SiddhiHome + configs.WSO2Dir + "/" + configs.SiddhiProfile + "/" + configs.FilePersistentDir
 	if spConf.StatePersistence.SPConfig.Location != "" && filepath.IsAbs(spConf.StatePersistence.SPConfig.Location) {
 		mountPath = spConf.StatePersistence.SPConfig.Location
 	} else if spConf.StatePersistence.SPConfig.Location != "" {
-		mountPath = configs.SiddhiHome + configs.SiddhiRunnerPath + spConf.StatePersistence.SPConfig.Location
+		mountPath = configs.SiddhiHome + configs.WSO2Dir + "/" + configs.SiddhiProfile + "/" + spConf.StatePersistence.SPConfig.Location
 	}
 	return
 }

--- a/pkg/controller/siddhiprocess/utils_test.go
+++ b/pkg/controller/siddhiprocess/utils_test.go
@@ -87,7 +87,7 @@ func TestPopulateMountPath(t *testing.T) {
 	}
 	testSP.Spec = spec
 	configs := getTestConfigs(testSP)
-	path := configs.SiddhiHome + configs.FilePersistentPath
+	path := configs.SiddhiHome + configs.WSO2Dir + "/" + configs.SiddhiProfile + "/" + configs.FilePersistentDir
 	p, err := populateMountPath(testSP, configs)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
## Purpose
> Resolve #52 

## Approach
> Get the paths from the siddhi-operator-config config map. Those paths are `siddhiHome` and `siddhiProfile`. Change the image name to `siddhiRunnerImage -> siddhiImage` to be consistent with namings in the config map. By default, we have the `bin/` directory and `wso2/` directory hardcoded. The paths are populated like below.
- path to the sh file = {SiddhiHome} + "bin/" + {SiddhiProfile} + ".sh"
- file persistence path = {SiddhiHome} + {SiddhiProfile} + "/siddhi-app-persistence"

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Change artifacts_test.go and utils_test.go

## Test environment
> minikube version: v1.2.0