### PR TITLE
Enable conditional create or update of the k8s deployments

### DIFF
--- a/pkg/controller/siddhiprocess/operator.go
+++ b/pkg/controller/siddhiprocess/operator.go
@@ -265,69 +265,69 @@ func (rsp *ReconcileSiddhiProcess) createArtifacts(
 		if (eventType == controllerutil.OperationResultCreated) ||
 			(eventType == controllerutil.OperationResultUpdated) {
 			needDep++
-		}
-		operationResult, err := rsp.deployApp(sp, siddhiApp, ER, configs)
-		if err != nil {
-			sp = rsp.updateErrorStatus(sp, ER, ERROR, "AppDeploymentError", err)
-			continue
-		}
-		if (eventType != controllerutil.OperationResultNone) &&
-			(operationResult == controllerutil.OperationResultCreated) {
-			availableDep++
-			sp = rsp.updateRunningStatus(
-				sp,
-				ER,
-				RUNNING,
-				"DeploymentCreated",
-				(siddhiApp.Name + " deployment created successfully"),
-			)
-		} else if (eventType != controllerutil.OperationResultNone) &&
-			(operationResult == controllerutil.OperationResultUpdated) {
-			availableDep++
-			sp = rsp.updateRunningStatus(
-				sp,
-				ER,
-				RUNNING,
-				"DeploymentUpdated",
-				(siddhiApp.Name + " deployment updated successfully"),
-			)
-		}
-
-		if siddhiApp.ServiceEnabled {
-			operationResult, err = rsp.CreateOrUpdateService(sp, siddhiApp, configs)
+			operationResult, err := rsp.deployApp(sp, siddhiApp, ER, configs)
 			if err != nil {
-				sp = rsp.updateErrorStatus(sp, ER, WARNING, "ServiceCreationError", err)
+				sp = rsp.updateErrorStatus(sp, ER, ERROR, "AppDeploymentError", err)
 				continue
 			}
 			if (eventType != controllerutil.OperationResultNone) &&
 				(operationResult == controllerutil.OperationResultCreated) {
+				availableDep++
 				sp = rsp.updateRunningStatus(
 					sp,
 					ER,
 					RUNNING,
-					"ServiceCreated",
-					(siddhiApp.Name + " service created successfully"),
+					"DeploymentCreated",
+					(siddhiApp.Name + " deployment created successfully"),
 				)
 			} else if (eventType != controllerutil.OperationResultNone) &&
 				(operationResult == controllerutil.OperationResultUpdated) {
+				availableDep++
 				sp = rsp.updateRunningStatus(
 					sp,
 					ER,
 					RUNNING,
-					"ServiceUpdated",
-					(siddhiApp.Name + " service updated successfully"),
+					"DeploymentUpdated",
+					(siddhiApp.Name + " deployment updated successfully"),
 				)
 			}
 
-			if configs.AutoCreateIngress {
-				err := rsp.CreateOrUpdateIngress(sp, siddhiApp, configs)
+			if siddhiApp.ServiceEnabled {
+				operationResult, err = rsp.CreateOrUpdateService(sp, siddhiApp, configs)
 				if err != nil {
-					sp = rsp.updateErrorStatus(sp, ER, ERROR, "IngressCreationError", err)
+					sp = rsp.updateErrorStatus(sp, ER, WARNING, "ServiceCreationError", err)
 					continue
 				}
-				if eventType == controllerutil.OperationResultCreated ||
-					eventType == controllerutil.OperationResultUpdated {
-					reqLogger.Info("Ingress changed", "Ingress.Name", configs.HostName)
+				if (eventType != controllerutil.OperationResultNone) &&
+					(operationResult == controllerutil.OperationResultCreated) {
+					sp = rsp.updateRunningStatus(
+						sp,
+						ER,
+						RUNNING,
+						"ServiceCreated",
+						(siddhiApp.Name + " service created successfully"),
+					)
+				} else if (eventType != controllerutil.OperationResultNone) &&
+					(operationResult == controllerutil.OperationResultUpdated) {
+					sp = rsp.updateRunningStatus(
+						sp,
+						ER,
+						RUNNING,
+						"ServiceUpdated",
+						(siddhiApp.Name + " service updated successfully"),
+					)
+				}
+
+				if configs.AutoCreateIngress {
+					err := rsp.CreateOrUpdateIngress(sp, siddhiApp, configs)
+					if err != nil {
+						sp = rsp.updateErrorStatus(sp, ER, ERROR, "IngressCreationError", err)
+						continue
+					}
+					if eventType == controllerutil.OperationResultCreated ||
+						eventType == controllerutil.OperationResultUpdated {
+						reqLogger.Info("Ingress changed", "Ingress.Name", configs.HostName)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Purpose
> Resolve #60.

## Approach
> Previously we create k8s artifacts(deployment, service, and ingress) without checking if there is a change the SiddhiProcess spec. Here we check for changes in the SiddhiProcess spec. We create or update k8s artifacts only if there is a spec change.

## Test environment
> minikube version: v1.2.0
 