### PR TITLE
Remove watch functions of NATS

### DIFF
--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -21,9 +21,7 @@ package siddhiprocess
 import (
 	"context"
 
-	natsv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/nats/v1alpha2"
 	siddhiv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/siddhi/v1alpha2"
-	streamingv1alpha1 "github.com/siddhi-io/siddhi-operator/pkg/apis/streaming/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -119,27 +117,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
-
-	// Watch for changes to secondary resource PersistentVolumeClaims and requeue the owner SiddhiProcess
-	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
-	})
-	if err != nil {
-		return err
-	}
-
-	// Watch for changes to secondary resource NatsClusters and requeue the owner SiddhiProcess
-	_ = c.Watch(&source.Kind{Type: &natsv1alpha2.NatsCluster{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
-	})
-
-	// Watch for changes to secondary resource NatsStreamingClusters and requeue the owner SiddhiProcess
-	_ = c.Watch(&source.Kind{Type: &streamingv1alpha1.NatsStreamingCluster{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &siddhiv1alpha2.SiddhiProcess{},
-	})
 
 	// Watch for changes to secondary resource Pods and requeue the owner SiddhiProcess
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{


### PR DESCRIPTION
## Purpose
Resolve #50 

## Approach
The `watch` functions that we had previously for NATS, listening to changes in NATS clusters. If NATS was not available in the cluster it will give an error as below.
```sh
"msg":"if kind is a CRD, it should be installed before calling Start","kind":"NatsCluster.nats.io","error":"no matches for kind \"NatsCluster\" in version \"nats.io/v1alpha2\""
```
But watching changes in NATS is an unnecessary task for the operator. So we simply remove those watchers.

## User stories
According to this issue, the operator now has two deployment types. 
1. Deploy in default mode(without NATS)
1. Deploy in distributed mode(with NATS)

Before deploying the Siddhi operator user has to decide either of above deployment types. Before deploying an operator we have to specify which types of resources that the operator has to handle. If NATS was not there when you deploy the operator, the operator simply ignores watching NATS. So this will lead to two questions as below.

1. How to deploy default Siddhi apps with the distributed mode(with NATS) of the Siddhi operator?
    - Here you do not have a problem. If you install NATS before Siddhi operator deployment, you can deploy default Siddhi apps afterward without any problem. 

1. How to deploy distributed Siddhi apps with the default mode(without NATS) of the Siddhi operator?
    - You cannot deploy distributed Siddhi apps without NATS. If you deploy Siddhi operator without NATS, the Siddhi operator does not have the capability to watch NATS resources. Therefore in this scenario, you have to install NATS and then you need to redeploy the Siddhi operator.

## Related PRs
> #51

## Test environment
> minikube version: v1.2.0

## Learning
Before deploying an operator, you have to specify all the CRDs that operator going to look at. And those resources should be in the k8s cluster when deploying the operator. The dynamic CRD registration does not support currently in operator sdk level according to this https://github.com/operator-framework/operator-sdk/issues/139 issue.