### PR TITLE
Enable version controlling for config map changes

### DIFF
--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_functions.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_functions.go
@@ -60,11 +60,11 @@ func (p *MessagingSystem) Equals(q *MessagingSystem) bool {
 	return (typeEq && cidEq)
 }
 
-// Equals 
+// Equals function checks the equality of two SiddhiProcess specs
 func (p *SiddhiProcessSpec) Equals(q *SiddhiProcessSpec) bool {
 	if !EqualApps(p.Apps, q.Apps) {
 		return false
-	}
+	} 
 	if p.SiddhiConfig != q.SiddhiConfig {
 		return false
 	}
@@ -83,7 +83,7 @@ func (p *SiddhiProcessSpec) Equals(q *SiddhiProcessSpec) bool {
 	return true
 }
 
-// EqualApps 
+// EqualApps checks the equality of two app slices
 func EqualApps(p []Apps, q []Apps) bool {
 	if len(p) != len(q) {
 		return false
@@ -103,7 +103,7 @@ func EqualApps(p []Apps, q []Apps) bool {
 	return true
 }
 
-// EqualContainers 
+// EqualContainers checks the equality of two container specs
 func EqualContainers(p *corev1.Container, q *corev1.Container) bool {
 	if p.Image != q.Image {
 		return false

--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
@@ -87,7 +87,8 @@ type SiddhiProcessSpec struct {
 type SiddhiProcessStatus struct {
 	Status string   `json:"status"`
 	Ready  string   `json:"ready"`
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	CurrentVersion int64 `json:"currentVersion"`
+	PreviousVersion int64 `json:"previousVersion"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/siddhiprocess/artifacts.go
+++ b/pkg/controller/siddhiprocess/artifacts.go
@@ -75,7 +75,7 @@ func (rsp *ReconcileSiddhiProcess) CreateOrUpdateIngress(
 	sp *siddhiv1alpha2.SiddhiProcess,
 	siddhiApp SiddhiApp,
 	configs Configs,
-) (err error) {
+) (operationResult controllerutil.OperationResult, err error) {
 
 	var ingressPaths []extensionsv1beta1.HTTPIngressPath
 	for _, port := range siddhiApp.ContainerPorts {
@@ -142,7 +142,7 @@ func (rsp *ReconcileSiddhiProcess) CreateOrUpdateIngress(
 		},
 		Spec: ingressSpec,
 	}
-	_, err = controllerutil.CreateOrUpdate(
+	operationResult, err = controllerutil.CreateOrUpdate(
 		context.TODO(),
 		rsp.client,
 		ingress,

--- a/pkg/controller/siddhiprocess/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifacts_test.go
@@ -64,7 +64,7 @@ func TestCreateOrUpdateIngress(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 	rsp := &ReconcileSiddhiProcess{client: cl, scheme: s}
 	configs := getTestConfigs(testSP)
-	err := rsp.CreateOrUpdateIngress(testSP, testSiddhiApp, configs)
+	_, err := rsp.CreateOrUpdateIngress(testSP, testSiddhiApp, configs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -86,7 +86,7 @@ func TestCreateOrUpdateIngress(t *testing.T) {
 		},
 		PersistenceEnabled: true,
 	}
-	err = rsp.CreateOrUpdateIngress(testSP, sa, configs)
+	_, err = rsp.CreateOrUpdateIngress(testSP, sa, configs)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -262,6 +262,12 @@ type SiddhiAppConfig struct {
 	Replicas                int32                    `json:"replicas"`
 }
 
+// ConfigMapListner holds the change details of a config map
+type ConfigMapListner struct {
+	SiddhiProcess string `json:"siddhiProcess"`
+	Changed       bool   `json:"changed"`
+}
+
 // Status of a Siddhi process
 type Status int
 


### PR DESCRIPTION
## Purpose
> Resolve #64  

## Approach
Previously we have enabled the version controlling in SiddhiProcess level. In SiddhiProcess deployments, user can specify SiddhiApps as config maps. If the user changes the given config map that change is not visible for SiddhiProcess. Therefore SiddhiProcess does not change. 

Here we add a primary watch function for config maps. From that, if someone changes the config map, the reconcile loop will trigger. We maintain an internal mapping for config map to SiddhiProcess. From that, we can identify the SiddhiProcess that we need to update when config map changes. Then the previous updating process of #57 continues the execution.

## User stories
User can change stateful -> stateless and stateless->stateful without any problem. The operator will create remaining K8s artifacts in stateless->stateful scenario. Also, the operator will remove unwanted K8s artifacts in stateful -> stateless scenario.

## Related PRs
> #57 

## Test environment
> minikube version: v1.2.0