### PR TITLE
Change example PV path to /home/siddhi_user/

### DIFF
--- a/deploy/examples/example-pv.yaml
+++ b/deploy/examples/example-pv.yaml
@@ -12,7 +12,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/home/docker/"
+    path: "/home/siddhi_user/"
   # For NFS in GKE use the following block
   # nfs:
   #   server: <SERVER_IP>


### PR DESCRIPTION
## Purpose
> Minikube cluster used in Katacoda sample has a different kind of directory structure compared to the local version. Since we are directly using these examples in Katacoda, it is better to have that kind of directory structure by default.

## Test environment
>  minikube version: v1.2.0 and [Katacoda](https://www.katacoda.com/)