### PR TITLE
Change the parser wait and retry timeouts

### DIFF
--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -127,9 +127,9 @@ const (
 	ParserName      string = "parser"
 	ParserPort      int32  = 9090
 	ParserReplicas  int32  = 1
-	ParserMinWait   int    = 5
-	ParserMaxWait   int    = 20
-	ParserMaxRetry  int    = 15
+	ParserMinWait   int    = 3
+	ParserMaxWait   int    = 5
+	ParserMaxRetry  int    = 20
 )
 
 // Int - Type


### PR DESCRIPTION
## Purpose
Change the timeouts for the parser retry and waiting process.

## Goals
Made quick retries to the parser. 

## Approach
- Minimum wait time change to 5s -> 3s
- Maximum wait time change to 20s -> 5s
- Maximum # of retries 15 -> 20

From that, we execute more retires to the parser compared to previous one within a short time period. So that we can quickly detect the availability of the parser. Here added more retries to give proper time-space to the deployment to download the docker image and deploy it.

## Test environment
minikube version: v1.2.0
 
## Learning
Sometimes if the network connection is slow operator may fail initially because it takes more time to download docker and deploy. Even it fails at one point it again starts to run when the parser becomes available. On the other hand, if we allocate more waiting time for the parser, then the parser will hang for a long time if there is an issue in the parser. So other events may be blocked a while.

Therefore here we allocate at maximum 100s(5x20) waiting time for the parser to balance both ends.