### PR TITLE
 Add waiting log for the parser

### DIFF
--- a/pkg/controller/siddhiprocess/operator.go
+++ b/pkg/controller/siddhiprocess/operator.go
@@ -173,6 +173,7 @@ func (rsp *ReconcileSiddhiProcess) deployApp(
 }
 
 func (rsp *ReconcileSiddhiProcess) deployParser(sp *siddhiv1alpha2.SiddhiProcess, configs Configs) (err error) {
+	reqLogger := log.WithValues("Request.Namespace", sp.Namespace, "Request.Name", sp.Name)
 	siddhiApp := SiddhiApp{
 		Name: sp.Name,
 		ContainerPorts: []corev1.ContainerPort{
@@ -195,6 +196,7 @@ func (rsp *ReconcileSiddhiProcess) deployParser(sp *siddhiv1alpha2.SiddhiProcess
 	}
 
 	url := configs.ParserHTTP + sp.Name + "." + sp.Namespace + configs.ParserHealth
+	reqLogger.Info("Waiting for parser", "deployment", sp.Name)
 	err = waitForParser(url)
 	if err != nil {
 		return


### PR DESCRIPTION
## Purpose
> Add waiting log for the parser. Hence, the user can see if there is a pending health check is happening to the parser. It is an indication that reconcile loop hangs until parser deployed successfully for a limited time period.

## Goals
> To give the user an idea that operator trying to connect to the parser.

## Approach
> Insert a waiting log.

## Test environment
> minikube version: v1.2.0
 