### PR TITLE
Add an extension to the name of the dynamic parser as -parser

### DIFF
--- a/pkg/controller/siddhiprocess/config.go
+++ b/pkg/controller/siddhiprocess/config.go
@@ -125,6 +125,7 @@ const (
 	OperatorCMName  string = "siddhi-operator-config"
 	ParserParameter string = "-Dsiddhi-parser "
 	ParserName      string = "parser"
+	ParserExtension string = "-parser"
 	ParserPort      int32  = 9090
 	ParserReplicas  int32  = 1
 	ParserMinWait   int    = 3

--- a/pkg/controller/siddhiprocess/operator.go
+++ b/pkg/controller/siddhiprocess/operator.go
@@ -175,7 +175,7 @@ func (rsp *ReconcileSiddhiProcess) deployApp(
 func (rsp *ReconcileSiddhiProcess) deployParser(sp *siddhiv1alpha2.SiddhiProcess, configs Configs) (err error) {
 	reqLogger := log.WithValues("Request.Namespace", sp.Namespace, "Request.Name", sp.Name)
 	siddhiApp := SiddhiApp{
-		Name: sp.Name,
+		Name: sp.Name + ParserExtension,
 		ContainerPorts: []corev1.ContainerPort{
 			corev1.ContainerPort{
 				Name:          ParserName,
@@ -195,7 +195,7 @@ func (rsp *ReconcileSiddhiProcess) deployParser(sp *siddhiv1alpha2.SiddhiProcess
 		return
 	}
 
-	url := configs.ParserHTTP + sp.Name + "." + sp.Namespace + configs.ParserHealth
+	url := configs.ParserHTTP + sp.Name + ParserExtension + "." + sp.Namespace + configs.ParserHealth
 	reqLogger.Info("Waiting for parser", "deployment", sp.Name)
 	err = waitForParser(url)
 	if err != nil {
@@ -554,11 +554,11 @@ func (rsp *ReconcileSiddhiProcess) cleanArtifacts(
 func (rsp *ReconcileSiddhiProcess) cleanParser(
 	sp *siddhiv1alpha2.SiddhiProcess,
 ) (err error) {
-	err = rsp.DeleteDeployment(sp.Name, sp.Namespace)
+	err = rsp.DeleteDeployment(sp.Name+ParserExtension, sp.Namespace)
 	if err != nil {
 		return
 	}
-	err = rsp.DeleteService(sp.Name, sp.Namespace)
+	err = rsp.DeleteService(sp.Name+ParserExtension, sp.Namespace)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/siddhiprocess/parser.go
+++ b/pkg/controller/siddhiprocess/parser.go
@@ -101,7 +101,7 @@ func invokeParser(
 	siddhiParserRequest SiddhiParserRequest,
 	configs Configs,
 ) (siddhiAppConfigs []SiddhiAppConfig, err error) {
-	url := configs.ParserHTTP + sp.Name + "." + sp.Namespace + configs.ParserContext
+	url := configs.ParserHTTP + sp.Name + ParserExtension + "." + sp.Namespace + configs.ParserContext
 	b, err := json.Marshal(siddhiParserRequest)
 	if err != nil {
 		return


### PR DESCRIPTION
## Purpose
The name of the dynamic parser sometimes confusing to the user. Hence we need a discriminated name for it.

## Goals
Having a discriminate name for the dynamic parser.

## Approach
Previously we have created the dynamic parser from the SiddhiProcess name. Here we added extra extension `-parser` to that SiddhiProcess name when we creating the parser.

## Related PRs
- https://github.com/siddhi-io/siddhi-operator/pull/71
- https://github.com/siddhi-io/katacoda-scenarios/pull/2

## Test environment
minikube version: v1.2.0