### PR TITLE
Rename clusterID config to clusterId

### DIFF
--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
@@ -48,7 +48,7 @@ type PV struct {
 
 // MessagingConfig contains the configs of the messaging layer
 type MessagingConfig struct {
-	ClusterID        string   `json:"clusterID"`
+	ClusterID        string   `json:"clusterId"`
 	BootstrapServers []string `json:"bootstrapServers"`
 }
 


### PR DESCRIPTION
## Purpose
The parser in the Siddhi runner has the naming `clusterId`.

## Test environment
minikube version: v1.2.0
