### PR TITLE
Change cluster ID naming in samples

### DIFF
--- a/deploy/examples/example-stateful-distributed-email-app.yaml
+++ b/deploy/examples/example-stateful-distributed-email-app.yaml
@@ -58,7 +58,7 @@ spec:
     # config: 
     #   bootstrapServers: 
     #     - "nats://siddhi-nats:4222"
-    #   clusterID: siddhi-stan
+    #   clusterId: siddhi-stan
   
   persistentVolume: 
     accessModes: 

--- a/deploy/examples/example-stateful-distributed-log-app.yaml
+++ b/deploy/examples/example-stateful-distributed-log-app.yaml
@@ -48,7 +48,7 @@ spec:
     # config: 
     #   bootstrapServers: 
     #     - "nats://nats-siddhi:4222"
-    #   clusterID: stan-siddhi
+    #   clusterId: stan-siddhi
   
   persistentVolume: 
     accessModes: 

--- a/deploy/examples/example-stateful-distributed-nats-app.yaml
+++ b/deploy/examples/example-stateful-distributed-nats-app.yaml
@@ -48,7 +48,7 @@ spec:
     config: 
       bootstrapServers: 
         - "nats://nats-siddhi:4222"
-      clusterID: stan-siddhi
+      clusterId: stan-siddhi
   
   persistentVolume: 
     accessModes: 


### PR DESCRIPTION
## Purpose
Change cluster-ID naming in samples. The previous naming of `clusterID` changed to `clusterId`.
