### PR TITLE
Change clusterId spec to streamingClusterId in messaging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ Now you can install the operator as describe in [previous installation](https://
 Execute the below command to start the unit tests.
 
 ```sh
-$ go test ./pkg/controller/siddhiprocess/
+$ go test ./pkg/controller/siddhiprocess/<PACKAGE_NAME>
+```
+
+For example, run the unit tests for package `artifact`.
+
+```sh
+$ go test ./pkg/controller/siddhiprocess/artifact
 ```
 
 #### E2E Tests

--- a/deploy/examples/example-stateful-distributed-email-app.yaml
+++ b/deploy/examples/example-stateful-distributed-email-app.yaml
@@ -58,7 +58,7 @@ spec:
     # config: 
     #   bootstrapServers: 
     #     - "nats://siddhi-nats:4222"
-    #   clusterId: siddhi-stan
+    #   streamingClusterId: siddhi-stan
   
   persistentVolumeClaim: 
     accessModes: 

--- a/deploy/examples/example-stateful-distributed-log-app.yaml
+++ b/deploy/examples/example-stateful-distributed-log-app.yaml
@@ -48,7 +48,7 @@ spec:
     # config: 
     #   bootstrapServers: 
     #     - "nats://nats-siddhi:4222"
-    #   clusterId: stan-siddhi
+    #   streamingClusterId: stan-siddhi
   
   persistentVolumeClaim: 
     accessModes: 

--- a/deploy/examples/example-stateful-distributed-nats-app.yaml
+++ b/deploy/examples/example-stateful-distributed-nats-app.yaml
@@ -48,7 +48,7 @@ spec:
     config: 
       bootstrapServers: 
         - "nats://nats-siddhi:4222"
-      clusterId: stan-siddhi
+      streamingClusterId: stan-siddhi
   
   persistentVolumeClaim: 
     accessModes: 

--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
@@ -30,7 +30,7 @@ type TLS struct {
 
 // MessagingConfig contains the configs of the messaging layer
 type MessagingConfig struct {
-	ClusterID        string   `json:"clusterId"`
+	ClusterID        string   `json:"streamingClusterId"`
 	BootstrapServers []string `json:"bootstrapServers"`
 }
 


### PR DESCRIPTION
## Purpose
Resolve #82.

## Goals
Change messaging config to be more descriptive.

## Approach
Change the messaging config spec. Here change previous `clusterId` to `streamingClusterId`.

## Release note
Update the messaging config spec like below.
```yaml
  messagingSystem:
    type: nats
    config: 
      bootstrapServers: 
        - "nats://nats-siddhi:4222"
      streamingClusterId: stan-siddhi
```

## Samples
Update the `deploy/examples/` according to the new changes.

## Test environment
minikube version: v1.2.0
