### PR TITLE
Change the tests according to the spec changes of messaging and pvc

### DIFF
--- a/deploy/examples/example-stateful-distributed-email-app.yaml
+++ b/deploy/examples/example-stateful-distributed-email-app.yaml
@@ -51,7 +51,7 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"
   
   messagingSystem:
     type: nats

--- a/deploy/examples/example-stateful-distributed-log-app.yaml
+++ b/deploy/examples/example-stateful-distributed-log-app.yaml
@@ -41,7 +41,7 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"
   
   messagingSystem:
     type: nats

--- a/deploy/examples/example-stateful-distributed-nats-app.yaml
+++ b/deploy/examples/example-stateful-distributed-nats-app.yaml
@@ -41,7 +41,7 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"
   
   messagingSystem:
     type: nats

--- a/deploy/examples/example-stateful-monolithic-log-app.yaml
+++ b/deploy/examples/example-stateful-monolithic-log-app.yaml
@@ -41,7 +41,7 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"
   
   persistentVolumeClaim: 
     accessModes: 

--- a/deploy/examples/example-stateless-email-app.yaml
+++ b/deploy/examples/example-stateless-email-app.yaml
@@ -47,4 +47,4 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"

--- a/deploy/examples/example-stateless-log-app.yaml
+++ b/deploy/examples/example-stateless-log-app.yaml
@@ -37,4 +37,4 @@ spec:
       - 
         name: BASIC_AUTH_ENABLED
         value: "false"
-    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-m2"
+    image: "siddhiio/siddhi-runner-ubuntu:5.1.0-alpha"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   siddhiHome: /home/siddhi_user/siddhi-runner/
   siddhiProfile: runner
-  siddhiImage: siddhiio/siddhi-runner-alpine:5.1.0-m2
+  siddhiImage: siddhiio/siddhi-runner-alpine:5.1.0-alpha
   autoIngressCreation: "true"
   # ingressTLS: siddhi-tls
 ---
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: siddhi-operator
       containers:
         - name: siddhi-operator
-          image: siddhiio/siddhi-operator:0.2.0-m2
+          image: siddhiio/siddhi-operator:0.2.0-alpha
           command:
           - siddhi-operator
           imagePullPolicy: Always
@@ -46,6 +46,6 @@ spec:
             - name: OPERATOR_NAME
               value: siddhi-operator
             - name: OPERATOR_VERSION
-              value: 0.2.0-m2
+              value: 0.2.0-alpha
             - name: OPERATOR_CONFIGMAP
               value: siddhi-operator-config

--- a/pkg/controller/siddhiprocess/artifact/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts_test.go
@@ -209,7 +209,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 		"app":     "sample",
 		"version": "0.1.0",
 	}
-	image := "siddhiio/siddhi-operator:0.2.0-m2"
+	image := "siddhiio/siddhi-operator:0.2.0-alpha"
 	_, err := kubeClient.CreateOrUpdateDeployment(
 		name,
 		namespace,

--- a/pkg/controller/siddhiprocess/deploymanager/constants.go
+++ b/pkg/controller/siddhiprocess/deploymanager/constants.go
@@ -21,7 +21,7 @@ package deploymanager
 // Constants for the DeployManager
 const (
 	OperatorName     string = "siddhi-operator"
-	OperatorVersion  string = "0.2.0-m2"
+	OperatorVersion  string = "0.2.0-alpha"
 	CRDName          string = "SiddhiProcess"
 	PVCExtension     string = "-pvc"
 	DepCMExtension   string = "-depyml"

--- a/pkg/controller/siddhiprocess/siddhicontroller/constants.go
+++ b/pkg/controller/siddhiprocess/siddhicontroller/constants.go
@@ -22,7 +22,7 @@ package siddhicontroller
 const (
 	OperatorCMName    string = "siddhi-operator-config"
 	SiddhiHome        string = "/home/siddhi_user/siddhi-runner/"
-	SiddhiImage       string = "siddhiio/siddhi-runner-alpine:5.1.0-m2"
+	SiddhiImage       string = "siddhiio/siddhi-runner-alpine:5.1.0-alpha"
 	SiddhiProfile     string = "runner"
 	AutoCreateIngress bool   = true
 )

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // failoverDeploymentTest check the failover deployment of a siddhi app.
@@ -37,7 +38,7 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
-
+	standardStorageClass := "standard"
 	// create SiddhiProcess custom resource
 	exampleSiddhi := &siddhiv1alpha2.SiddhiProcess{
 		TypeMeta: metav1.TypeMeta{
@@ -68,6 +69,17 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 			},
 			MessagingSystem: siddhiv1alpha2.MessagingSystem{
 				Type: "nats",
+			},
+			PVC: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+					},
+				},
+				StorageClassName: &standardStorageClass,
 			},
 		},
 	}
@@ -114,7 +126,7 @@ func failoverConfigChangeTest(t *testing.T, f *framework.Framework, ctx *framewo
 	if err != nil {
 		t.Fatalf("could not get namespace: %v", err)
 	}
-
+	standardStorageClass := "standard"
 	// create SiddhiProcess custom resource
 	exampleSiddhi := &siddhiv1alpha2.SiddhiProcess{
 		TypeMeta: metav1.TypeMeta{
@@ -147,6 +159,17 @@ func failoverConfigChangeTest(t *testing.T, f *framework.Framework, ctx *framewo
 				Type: "nats",
 			},
 			SiddhiConfig: StatePersistenceConf,
+			PVC: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+					},
+				},
+				StorageClassName: &standardStorageClass,
+			},
 		},
 	}
 
@@ -184,11 +207,12 @@ func failoverPVCTest(t *testing.T, f *framework.Framework, ctx *framework.TestCt
 		t.Fatalf("could not get namespace: %v", err)
 	}
 
+	standardStorageClass := "standard"
 	// create SiddhiProcess custom resource
 	exampleSiddhi := &siddhiv1alpha2.SiddhiProcess{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SiddhiProcess",
-			APIVersion: "siddhi.io/v1alpha1",
+			APIVersion: "siddhi.io/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "failover-test-app",
@@ -215,17 +239,16 @@ func failoverPVCTest(t *testing.T, f *framework.Framework, ctx *framework.TestCt
 			MessagingSystem: siddhiv1alpha2.MessagingSystem{
 				Type: "nats",
 			},
-			PV: siddhiv1alpha2.PV{
-				AccessModes: []string{
-					"ReadWriteOnce",
+			PVC: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
 				},
-				VolumeMode: "Filesystem",
-				Resources: siddhiv1alpha2.PVCResource{
-					Requests: siddhiv1alpha2.PVCRequest{
-						Storage: "1Gi",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
 					},
 				},
-				Class: "standard",
+				StorageClassName: &standardStorageClass,
 			},
 		},
 	}

--- a/test/e2e/siddhiprocess_test.go
+++ b/test/e2e/siddhiprocess_test.go
@@ -31,9 +31,9 @@ import (
 )
 
 var (
-	retryInterval        = time.Second * 5
+	retryInterval        = time.Second * 20
 	timeout              = time.Second * 80
-	maxTimeout           = time.Second * 100
+	maxTimeout           = time.Second * 150
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )
@@ -48,7 +48,7 @@ func TestSiddhiProcess(t *testing.T) {
 	siddhiList := &siddhiv1alpha2.SiddhiProcessList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SiddhiProcess",
-			APIVersion: "siddhi.io/v1alpha1",
+			APIVersion: "siddhi.io/v1alpha2",
 		},
 	}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, siddhiList)


### PR DESCRIPTION
## Purpose
Change tests according to the spec changes #82

## Goals
Update the E2E tests.

## Approach
- Change PVC spec and messaging system spec of tests.
- Increase testing timeout due to the dynamic parser.

## Automation tests
 - Integration tests
   > Change failover tests.

## Related PRs
- #83 
- #84 

## Test environment
minikube version: v1.2.0