### PR TITLE
Fix pvc creation segmentation fault error

### DIFF
--- a/pkg/controller/siddhiprocess/artifact/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts_test.go
@@ -155,9 +155,17 @@ func TestCreateOrUpdatePVC(t *testing.T) {
 		corev1.ReadWriteOnce,
 		corev1.ReadWriteMany,
 	}
-	storage := resource.MustParse("1Gi")
 	storageClassName := "standard"
-	err := kubeClient.CreateOrUpdatePVC(name, namespace, accessModes, storage, storageClassName, sampleDeployment)
+	pvcSpec := corev1.PersistentVolumeClaimSpec{
+		AccessModes:      accessModes,
+		StorageClassName: &storageClassName,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+			},
+		},
+	}
+	err := kubeClient.CreateOrUpdatePVC(name, namespace, pvcSpec, sampleDeployment)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/controller/siddhiprocess/deploymanager/application.go
+++ b/pkg/controller/siddhiprocess/deploymanager/application.go
@@ -111,9 +111,7 @@ func (d *DeployManager) Deploy() (operationResult controllerutil.OperationResult
 			err = d.KubeClient.CreateOrUpdatePVC(
 				pvcName,
 				d.SiddhiProcess.Namespace,
-				d.SiddhiProcess.Spec.PVC.AccessModes,
-				d.SiddhiProcess.Spec.PVC.Resources.Requests[corev1.ResourceStorage],
-				*d.SiddhiProcess.Spec.PVC.StorageClassName,
+				d.SiddhiProcess.Spec.PVC,
 				d.SiddhiProcess,
 			)
 			if err != nil {


### PR DESCRIPTION
## Purpose
Resolve #86.

## Goals
Prevent from PVC creation segmentation fault and operator crash.

## Approach
Directly map the user given PVC spec to the PVC create or update function.

## Release note
Fix segmentation fault in automatic PVC creation.

## Automation tests
 - Unit tests 
   > Update the artifact unit tests

## Test environment
minikube version: v1.2.0