### PR TITLE
Resolve the failure of the stateful app when PVC not specified

### DIFF
--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_functions.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_functions.go
@@ -27,10 +27,17 @@ import (
 
 // EqualsPVCSpec function of PVC check the equality of two PV structs
 func EqualsPVCSpec(p *corev1.PersistentVolumeClaimSpec, q *corev1.PersistentVolumeClaimSpec) bool {
-	vmEq := p.VolumeMode == q.VolumeMode
+	vmEq := false
+	if p.VolumeMode != nil && q.VolumeMode != nil {
+		vmEq = *p.VolumeMode == *q.VolumeMode
+	} else if p.VolumeMode == nil && q.VolumeMode == nil {
+		vmEq = true
+	}
 	classEq := false
 	if p.StorageClassName != nil && q.StorageClassName != nil {
 		classEq = *p.StorageClassName == *q.StorageClassName
+	} else if p.StorageClassName == nil && q.StorageClassName == nil {
+		classEq = true
 	}
 	resourceEq := reflect.DeepEqual(p.Resources, q.Resources)
 	if len(p.AccessModes) != len(q.AccessModes) {
@@ -75,7 +82,7 @@ func (p *SiddhiProcessSpec) Equals(q *SiddhiProcessSpec) bool {
 	if !p.MessagingSystem.Equals(&q.MessagingSystem) {
 		return false
 	}
-	if EqualsPVCSpec(&p.PVC, &q.PVC) {
+	if !EqualsPVCSpec(&p.PVC, &q.PVC) {
 		return false
 	}
 	if p.ImagePullSecret != q.ImagePullSecret {


### PR DESCRIPTION
## Purpose
Resolve #92 

## Goals
Prevent from Siddhi app deployment failure that occurs when the user does not specify the PVC spec for stateful Siddhi apps.

## Approach
Update the `EqualsPVCSpec` function that can compare the PVC spec provided by the `k8s.io/api/core/v1` library.

## User stories
Now users can deploy stateful Siddhi apps without specifying PVC spec. In other words, users can deploy stateful Siddhi apps in a stateless mode according to their requirements.

## Release note
Resolve the failure of the stateful app when PVC spec does not specify in the SiddhiProcess YAML.

## Test environment
- Minikube version: v1.2.0
- Kubernetes server v1.15.0
- Kubernetes client v1.11.3