### PR TITLE
Bump operator version to beta and fix e2e test

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: siddhi-operator
       containers:
         - name: siddhi-operator
-          image: siddhiio/siddhi-operator:0.2.0-alpha
+          image: siddhiio/siddhi-operator:0.2.0-beta
           command:
           - siddhi-operator
           imagePullPolicy: Always
@@ -46,6 +46,6 @@ spec:
             - name: OPERATOR_NAME
               value: siddhi-operator
             - name: OPERATOR_VERSION
-              value: 0.2.0-alpha
+              value: 0.2.0-beta
             - name: OPERATOR_CONFIGMAP
               value: siddhi-operator-config

--- a/pkg/controller/siddhiprocess/artifact/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts_test.go
@@ -217,7 +217,7 @@ func TestCreateOrUpdateDeployment(t *testing.T) {
 		"app":     "sample",
 		"version": "0.1.0",
 	}
-	image := "siddhiio/siddhi-operator:0.2.0-alpha"
+	image := "siddhiio/siddhi-operator:0.2.0-beta"
 	_, err := kubeClient.CreateOrUpdateDeployment(
 		name,
 		namespace,

--- a/pkg/controller/siddhiprocess/deploymanager/constants.go
+++ b/pkg/controller/siddhiprocess/deploymanager/constants.go
@@ -21,7 +21,7 @@ package deploymanager
 // Constants for the DeployManager
 const (
 	OperatorName     string = "siddhi-operator"
-	OperatorVersion  string = "0.2.0-alpha"
+	OperatorVersion  string = "0.2.0-beta"
 	CRDName          string = "SiddhiProcess"
 	PVCExtension     string = "-pvc"
 	DepCMExtension   string = "-depyml"

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -46,7 +46,7 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 			APIVersion: "siddhi.io/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "failover-app",
+			Name:      "failover-app-dep",
 			Namespace: namespace,
 		},
 		Spec: siddhiv1alpha2.SiddhiProcessSpec{
@@ -89,12 +89,12 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-0", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-dep-0", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-1", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-dep-1", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	_, err = f.KubeClient.CoreV1().Services(namespace).Get("failover-app-0", metav1.GetOptions{IncludeUninitialized: true})
+	_, err = f.KubeClient.CoreV1().Services(namespace).Get("failover-app-dep-0", metav1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func failoverConfigChangeTest(t *testing.T, f *framework.Framework, ctx *framewo
 			APIVersion: "siddhi.io/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "failover-app",
+			Name:      "failover-app-conf",
 			Namespace: namespace,
 		},
 		Spec: siddhiv1alpha2.SiddhiProcessSpec{
@@ -178,17 +178,17 @@ func failoverConfigChangeTest(t *testing.T, f *framework.Framework, ctx *framewo
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-0", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-conf-0", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-1", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-conf-1", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
 
-	_, err = f.KubeClient.CoreV1().ConfigMaps(namespace).Get("failover-app-depyml", metav1.GetOptions{IncludeUninitialized: true})
+	_, err = f.KubeClient.CoreV1().ConfigMaps(namespace).Get("failover-app-conf-depyml", metav1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func failoverPVCTest(t *testing.T, f *framework.Framework, ctx *framework.TestCt
 			APIVersion: "siddhi.io/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "failover-test-app",
+			Name:      "failover-app-pvc",
 			Namespace: namespace,
 		},
 		Spec: siddhiv1alpha2.SiddhiProcessSpec{
@@ -258,17 +258,17 @@ func failoverPVCTest(t *testing.T, f *framework.Framework, ctx *framework.TestCt
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-test-app-0", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-pvc-0", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-test-app-1", 1, retryInterval, maxTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "failover-app-pvc-1", 1, retryInterval, maxTimeout)
 	if err != nil {
 		return err
 	}
 
-	_, err = f.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get("failover-test-app-1-pvc", metav1.GetOptions{IncludeUninitialized: true})
+	_, err = f.KubeClient.CoreV1().PersistentVolumeClaims(namespace).Get("failover-app-pvc-1-pvc", metav1.GetOptions{IncludeUninitialized: true})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Purpose
$subject

## Goals
To fix the intermittent failure of failover tests.

## Approach
The test failure happened due to using the same SiddhiProcess name in each test. So that some K8s artifacts like PVC might delete in the first test and second test waiting for that resource to be created. To resolve that use different names for each SiddhiProcess.

## Test environment
minikube version: v1.2.0
