### PR TITLE
Fix local imagePullSecret skip issue

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -9,6 +9,7 @@ data:
   siddhiProfile: runner
   siddhiImage: siddhiio/siddhi-runner-alpine:5.1.0-beta
   autoIngressCreation: "true"
+  # siddhiImageSecret: siddhiio
   # ingressTLS: siddhi-tls
 ---
 

--- a/pkg/controller/siddhiprocess/siddhicontroller/siddhicontroller.go
+++ b/pkg/controller/siddhiprocess/siddhicontroller/siddhicontroller.go
@@ -330,16 +330,10 @@ func (sc *SiddhiController) UpdateDefaultConfigs() {
 
 		if configMap.Data["siddhiImage"] != "" {
 			sc.Image.Name = configMap.Data["siddhiImage"]
-			if sc.SiddhiProcess.Spec.Container.Image != "" {
-				sc.Image.Name = sc.SiddhiProcess.Spec.Container.Image
-			}
 		}
 
 		if configMap.Data["siddhiImageSecret"] != "" {
 			sc.Image.Secret = configMap.Data["siddhiImageSecret"]
-			if sc.SiddhiProcess.Spec.ImagePullSecret != "" {
-				sc.Image.Secret = sc.SiddhiProcess.Spec.ImagePullSecret
-			}
 		}
 
 		if configMap.Data["siddhiProfile"] != "" {
@@ -356,5 +350,11 @@ func (sc *SiddhiController) UpdateDefaultConfigs() {
 			sc.TLS = configMap.Data["ingressTLS"]
 		}
 
+	}
+	if sc.SiddhiProcess.Spec.Container.Image != "" {
+		sc.Image.Name = sc.SiddhiProcess.Spec.Container.Image
+	}
+	if sc.SiddhiProcess.Spec.ImagePullSecret != "" {
+		sc.Image.Secret = sc.SiddhiProcess.Spec.ImagePullSecret
 	}
 }


### PR DESCRIPTION
## Purpose
$subject

## Goals
To add multi-level image and imagePullSecrets.
- Operator config level
- SiddhiProcess level

## Approach
Previously we change the image configs of SiddhiProcess after changing the operator level config. So that if operator config were missing SiddhiProcess level config change will not occur. Therefore here we isolate these two config changes.

## Release note
Fix the issue of skiping `SiddhiProcess` level image configs(image name and image pull secret) when operator level config missing.

## Test environment
minikube version: v1.2.0
 