### PR TITLE
Replace create from apply because apply is more suitable for YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ Supported Version: nginx 0.22.0+
 
 2. Execute the following commands to setup the Siddhi Operator in the kubernetes cluster.
    ```sh
-    kubectl create -f ./deploy/siddhi_v1alpha2_siddhiprocess_crd.yaml
-    kubectl create -f ./deploy/service_account.yaml
-    kubectl create -f ./deploy/role.yaml
-    kubectl create -f ./deploy/role_binding.yaml
-    kubectl create -f ./deploy/operator.yaml
+    kubectl apply -f ./deploy/siddhi_v1alpha2_siddhiprocess_crd.yaml
+    kubectl apply -f ./deploy/service_account.yaml
+    kubectl apply -f ./deploy/role.yaml
+    kubectl apply -f ./deploy/role_binding.yaml
+    kubectl apply -f ./deploy/operator.yaml
    ```
     
 ## Testing a sample
 
 1. Execute the below command to create a sample siddhi deployment.  
-`kubectl create -f ./deploy/examples/example-stateless-log-app.yaml`
+`kubectl apply -f ./deploy/examples/example-stateless-log-app.yaml`
 
    Siddhi Operator would create a Siddhi-Runner deployment with the Siddhi app deployed through the example-siddhi-app CRD, a service, and an ingress to expose the http endpoint which is in the Siddhi sample.
    
@@ -190,11 +190,11 @@ Execute the below commands to set up the needed infrastructure for the test-case
 1. Then you have to set up the siddhi-operator in `operator-test` namespace using following commands.
 
    ``` sh
-   $ kubectl create -f ./deploy/siddhi_v1alpha2_siddhiprocess_crd.yaml --namespace operator-test
-   $ kubectl create -f ./deploy/service_account.yaml --namespace operator-test
-   $ kubectl create -f ./deploy/role.yaml --namespace operator-test
-   $ kubectl create -f ./deploy/role_binding.yaml --namespace operator-test
-   $ kubectl create -f ./deploy/operator.yaml --namespace operator-test
+   $ kubectl apply -f ./deploy/siddhi_v1alpha2_siddhiprocess_crd.yaml --namespace operator-test
+   $ kubectl apply -f ./deploy/service_account.yaml --namespace operator-test
+   $ kubectl apply -f ./deploy/role.yaml --namespace operator-test
+   $ kubectl apply -f ./deploy/role_binding.yaml --namespace operator-test
+   $ kubectl apply -f ./deploy/operator.yaml --namespace operator-test
    ```
 
 1. Finally, test the operator using following command.


### PR DESCRIPTION
## Purpose
$subject

## Approach
The reason for this change is `kubectl apply` is more convenient to use than `kubectl create`. If the user uses `kubectl create` it will apply the changes along with a warning message. But `kubectl apply` just execute an insert or update without any issue or warning.

## Test environment
```sh
Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.3", GitCommit:"a4529464e4629c21224b3d52edfe0ea91b072862", GitTreeState:"clean", BuildDate:"2018-09-09T18:02:47Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.0", GitCommit:"e8462b5b5dc2584fdcd18e6bcfe9f1e4d970a529", GitTreeState:"clean", BuildDate:"2019-06-19T16:32:14Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"linux/amd64"}
```
