### PR TITLE
Set up readiness and liveness probes in deployment mutate function

### DIFF
--- a/pkg/controller/siddhiprocess/artifact/artifacts.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts.go
@@ -424,6 +424,9 @@ func (k *KubeClient) CreateOrUpdateDeployment(
 			ipp,
 			secrets,
 			volumes,
+			readyProbe,
+			liveProbe,
+			strategy,
 		),
 	)
 	return
@@ -554,6 +557,9 @@ func DeploymentMutateFunc(
 	ipp corev1.PullPolicy,
 	secrets []corev1.LocalObjectReference,
 	volumes []corev1.Volume,
+	readyProbe corev1.Probe,
+	liveProbe corev1.Probe,
+	strategy appsv1.DeploymentStrategy,
 ) controllerutil.MutateFn {
 	return func(obj runtime.Object) error {
 		deployment := obj.(*appsv1.Deployment)
@@ -569,11 +575,14 @@ func DeploymentMutateFunc(
 					Env:             envs,
 					SecurityContext: &sc,
 					ImagePullPolicy: ipp,
+					ReadinessProbe:  &readyProbe,
+					LivenessProbe:   &liveProbe,
 				},
 			},
 			ImagePullSecrets: secrets,
 			Volumes:          volumes,
 		}
+		deployment.Spec.Strategy = strategy
 		return nil
 	}
 }


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/siddhi-operator/issues/104.

## Goals
Add readiness and liveness probes.

## Approach
Add readiness and liveness probes to the `MutateFunction` of the deployment.

## Related PRs
https://github.com/siddhi-io/siddhi-operator/pull/46

## Test environment
minikube version: v1.4.0
 
## Learning
Note that, in any `MutateFunction`, if we are changing a particular structure then we have to change the entire structure. Not the specs that we exactly want to change. The reason is when `MutateFunction` update the K8s struct, it will assign default values for unspecified values.