### PR TITLE
Add initial pending state and intermediate updating state

### DIFF
--- a/pkg/controller/siddhiprocess/artifact/artifacts.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts.go
@@ -512,6 +512,23 @@ func (k *KubeClient) DeleteConfigMap(
 	return
 }
 
+// GetDeployment return the deployment struct if it is exists along with a flag indicating whether it is exists or not
+func (k *KubeClient) GetDeployment(
+	name string,
+	namespace string,
+) (*appsv1.Deployment, bool) {
+	deployment := &appsv1.Deployment{}
+	err := k.Client.Get(
+		context.TODO(),
+		types.NamespacedName{Name: strings.ToLower(name), Namespace: namespace},
+		deployment,
+	)
+	if err == nil {
+		return deployment, true
+	}
+	return deployment, false
+}
+
 // ConfigMapMutateFunc is the function for update k8s config maps gracefully
 func ConfigMapMutateFunc(data map[string]string) controllerutil.MutateFn {
 	return func(obj runtime.Object) error {

--- a/pkg/controller/siddhiprocess/siddhicontroller/constants.go
+++ b/pkg/controller/siddhiprocess/siddhicontroller/constants.go
@@ -35,4 +35,5 @@ const (
 	ERROR
 	WARNING
 	NORMAL
+	UPDATING
 )

--- a/pkg/controller/siddhiprocess/siddhicontroller/status.go
+++ b/pkg/controller/siddhiprocess/siddhicontroller/status.go
@@ -29,6 +29,7 @@ var status = []string{
 	"Error",
 	"Warning",
 	"Normal",
+	"Updating",
 }
 
 // getStatus return relevant status to a given integer. This uses status array and the constants list.

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -204,6 +204,7 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 		},
 	}
 	siddhiController.UpdateDefaultConfigs()
+	siddhiController.SetDefaultPendingState()
 	if !SiddhiProcessChanged {
 		siddhiController.UpgradeVersion()
 		sp = siddhiController.SiddhiProcess


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/siddhi-operator/issues/90

## Goals
$subject

## Approach
- Initially, in the reconcile loop, we check whether the request type in create and the status of the current object is empty. If so we set the state to pending.
- When we got an update request, check whether the deployment count is greater than zero. If so, we set the state as pending.

## Release note
Add initial pending state and intermediate updating state to the `SiddhiProcess` custom resource object.

## Test environment
minikube version: v1.4.0
 