### PR TITLE
Make SiddhiProcess status running when pods become available

### DIFF
--- a/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
+++ b/pkg/apis/siddhi/v1alpha2/siddhiprocess_types.go
@@ -64,6 +64,7 @@ type SiddhiProcessStatus struct {
 	Ready           string `json:"ready"`
 	CurrentVersion  int64  `json:"currentVersion"`
 	PreviousVersion int64  `json:"previousVersion"`
+	EventType       string `json:"eventType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/siddhiprocess/constants.go
+++ b/pkg/controller/siddhiprocess/constants.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package siddhiprocess
+
+// EventType holds the type of a event
+type EventType int
+
+// siddhiprocess package constants
+const (
+	ReconcileTime int = 5
+)
+
+// Type of events that publishes to the reconcile loop
+const (
+	CREATE EventType = iota
+	UPDATE
+	DELETE
+	GENERIC
+	TIMER
+)
+
+// eventType array holds the string values of event types
+var eventType = []string{
+	"Create",
+	"Update",
+	"Delete",
+	"Generic",
+	"Timer",
+}
+
+// getEventType returns the type of a event
+func getEventType(n EventType) string {
+	return eventType[n]
+}

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -20,6 +20,7 @@ package siddhiprocess
 
 import (
 	"context"
+	"time"
 
 	siddhiv1alpha2 "github.com/siddhi-io/siddhi-operator/pkg/apis/siddhi/v1alpha2"
 	artifact "github.com/siddhi-io/siddhi-operator/pkg/controller/siddhiprocess/artifact"
@@ -91,8 +92,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			newObject := e.ObjectNew.(*siddhiv1alpha2.SiddhiProcess)
 			if !oldObject.Spec.Equals(&newObject.Spec) {
 				newObject.Status.CurrentVersion++
+				newObject.Status.EventType = getEventType(UPDATE)
 				return true
 			}
+			newObject.Status.EventType = getEventType(TIMER)
 			return false
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -179,12 +182,12 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 	sp := &siddhiv1alpha2.SiddhiProcess{}
 	cm := &corev1.ConfigMap{}
 	siddhiProcessName := request.NamespacedName
-	SiddhiProcessChanged := true
+	siddhiProcessChanged := true
 	err := rsp.client.Get(context.TODO(), request.NamespacedName, cm)
 	if err == nil {
 		cmListner := CMContainer[request.NamespacedName.Name]
 		siddhiProcessName.Name = cmListner.SiddhiProcess
-		SiddhiProcessChanged = false
+		siddhiProcessChanged = false
 	}
 
 	err = rsp.client.Get(context.TODO(), siddhiProcessName, sp)
@@ -194,6 +197,7 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 		}
 		return reconcile.Result{}, err
 	}
+
 	siddhiController := &siddhicontroller.SiddhiController{
 		SiddhiProcess: sp,
 		EventRecorder: ER,
@@ -204,8 +208,19 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 		},
 	}
 	siddhiController.UpdateDefaultConfigs()
+
+	if sp.Status.EventType == getEventType(TIMER) {
+		if SPContainer[sp.Name] != nil {
+			terminate := siddhiController.CheckAvailableDeployments(SPContainer[sp.Name])
+			if terminate {
+				return reconcile.Result{Requeue: false}, nil
+			}
+		}
+		return reconcile.Result{RequeueAfter: time.Second * time.Duration(ReconcileTime)}, nil
+	}
+
 	siddhiController.SetDefaultPendingState()
-	if !SiddhiProcessChanged {
+	if !siddhiProcessChanged {
 		siddhiController.UpgradeVersion()
 		sp = siddhiController.SiddhiProcess
 	}
@@ -249,12 +264,12 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 
 	siddhiController.CreateArtifacts(apps)
 	siddhiController.CheckDeployments(apps)
-	if !SiddhiProcessChanged {
+	if !siddhiProcessChanged {
 		cmListner := CMContainer[request.NamespacedName.Name]
 		cmListner.Changed = false
 		CMContainer[request.NamespacedName.Name] = cmListner
 	}
-	return reconcile.Result{Requeue: false}, nil
+	return reconcile.Result{RequeueAfter: time.Second * time.Duration(ReconcileTime)}, nil
 }
 
 // populateSiddhiApps function invoke parserApp function to retrieve relevant siddhi apps.


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/siddhi-operator/issues/80

## Goals
$subject

## Approach
Add periodic health check to deployment spec called `availableReplicas`. Check periodically the available replicas. When all are up and running then terminate the periodic health check.

## Release note
Enable users to view the `READY` status when pods become available.

## Test environment
minikube version: v1.4.0
commit: 7969c25a98a018b94ea87d949350f3271e9d64b6
