### PR TITLE
Increase the retrying time for parser

### DIFF
--- a/pkg/controller/siddhiprocess/constants.go
+++ b/pkg/controller/siddhiprocess/constants.go
@@ -23,7 +23,8 @@ type EventType int
 
 // siddhiprocess package constants
 const (
-	ReconcileTime int = 5
+	ReconcileTime       int = 2
+	ParserFailRetryTime int = 1
 )
 
 // Type of events that publishes to the reconcile loop

--- a/pkg/controller/siddhiprocess/parser/constants.go
+++ b/pkg/controller/siddhiprocess/parser/constants.go
@@ -31,6 +31,6 @@ const (
 	ParserPort        int32  = 9090
 	ParserReplicas    int32  = 1
 	ParserMinWait     int    = 3
-	ParserMaxWait     int    = 5
-	ParserMaxRetry    int    = 20
+	ParserMaxWait     int    = 10
+	ParserMaxRetry    int    = 40
 )

--- a/pkg/controller/siddhiprocess/parser/constants.go
+++ b/pkg/controller/siddhiprocess/parser/constants.go
@@ -32,5 +32,5 @@ const (
 	ParserReplicas    int32  = 1
 	ParserMinWait     int    = 3
 	ParserMaxWait     int    = 10
-	ParserMaxRetry    int    = 40
+	ParserMaxRetry    int    = 6
 )

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -215,8 +215,8 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 			if terminate {
 				return reconcile.Result{Requeue: false}, nil
 			}
+			return reconcile.Result{RequeueAfter: time.Minute * time.Duration(ParserFailRetryTime)}, nil
 		}
-		return reconcile.Result{RequeueAfter: time.Second * time.Duration(ReconcileTime)}, nil
 	}
 
 	siddhiController.SetDefaultPendingState()
@@ -247,7 +247,7 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 	apps, err := rsp.populateSiddhiApps(sp, parser, siddhiController)
 	if err != nil {
 		siddhiController.UpdateErrorStatus("ParserFailed", err)
-		return reconcile.Result{}, nil
+		return reconcile.Result{RequeueAfter: time.Second * time.Duration(ParserFailRetryTime)}, nil
 	}
 	sp = siddhiController.SiddhiProcess
 	messaging := messaging.Messaging{

--- a/pkg/controller/siddhiprocess/siddhiprocess_controller.go
+++ b/pkg/controller/siddhiprocess/siddhiprocess_controller.go
@@ -215,7 +215,7 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 			if terminate {
 				return reconcile.Result{Requeue: false}, nil
 			}
-			return reconcile.Result{RequeueAfter: time.Minute * time.Duration(ParserFailRetryTime)}, nil
+			return reconcile.Result{RequeueAfter: time.Minute * time.Duration(ReconcileTime)}, nil
 		}
 	}
 
@@ -247,7 +247,7 @@ func (rsp *ReconcileSiddhiProcess) Reconcile(request reconcile.Request) (reconci
 	apps, err := rsp.populateSiddhiApps(sp, parser, siddhiController)
 	if err != nil {
 		siddhiController.UpdateErrorStatus("ParserFailed", err)
-		return reconcile.Result{RequeueAfter: time.Second * time.Duration(ParserFailRetryTime)}, nil
+		return reconcile.Result{RequeueAfter: time.Minute * time.Duration(ParserFailRetryTime)}, nil
 	}
 	sp = siddhiController.SiddhiProcess
 	messaging := messaging.Messaging{


### PR DESCRIPTION
## Purpose
$subject

## Goals
To prevent from hanging the parser when the Docker download time is high.

## Approach
- Increase retrying time.
- Generate a retry time event if the parser fails.

## Test environment
minikube version: v1.4.0
