### PR TITLE
Use constant GigaByte for the default storage quantity

### DIFF
--- a/pkg/controller/siddhiprocess/artifact/artifacts_test.go
+++ b/pkg/controller/siddhiprocess/artifact/artifacts_test.go
@@ -160,7 +160,7 @@ func TestCreateOrUpdatePVC(t *testing.T) {
 		StorageClassName: &storageClassName,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+				corev1.ResourceStorage: *resource.NewQuantity(1*GigaByte, resource.BinarySI),
 			},
 		},
 	}

--- a/pkg/controller/siddhiprocess/artifact/constants.go
+++ b/pkg/controller/siddhiprocess/artifact/constants.go
@@ -33,6 +33,7 @@ const (
 	STANKind        string = "NatsStreamingCluster"
 	NATSClusterSize int    = 1
 	STANClusterSize int32  = 1
+	GigaByte        int64  = 1024 * 1024 * 1024
 )
 
 // Constants for K8s deployment

--- a/test/e2e/default_test.go
+++ b/test/e2e/default_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 const (
+	GigaByte int64  = 1024*1024*1024
 	StatePersistenceConf string = `
 statePersistence:
   enabled: true

--- a/test/e2e/failover_test.go
+++ b/test/e2e/failover_test.go
@@ -76,7 +76,7 @@ func failoverDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+						corev1.ResourceStorage: *resource.NewQuantity(1*GigaByte, resource.BinarySI),
 					},
 				},
 				StorageClassName: &standardStorageClass,
@@ -165,7 +165,7 @@ func failoverConfigChangeTest(t *testing.T, f *framework.Framework, ctx *framewo
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+						corev1.ResourceStorage: *resource.NewQuantity(1*GigaByte, resource.BinarySI),
 					},
 				},
 				StorageClassName: &standardStorageClass,
@@ -245,7 +245,7 @@ func failoverPVCTest(t *testing.T, f *framework.Framework, ctx *framework.TestCt
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
+						corev1.ResourceStorage: *resource.NewQuantity(1*GigaByte, resource.BinarySI),
 					},
 				},
 				StorageClassName: &standardStorageClass,


### PR DESCRIPTION
## Purpose
$subject

## Approach
Introduce a constant call `GigaByte`

## Related PRs
https://github.com/siddhi-io/siddhi-operator/pull/85

## Test environment
minikube version: v1.4.0