### PR TITLE
Enable error handling when NATS not installed in distributed mode

### DIFF
--- a/pkg/controller/siddhiprocess/messaging/constants.go
+++ b/pkg/controller/siddhiprocess/messaging/constants.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package messaging
+
+// Constants for the NATS messaging system
+const (
+	NATSOperatorName string = "nats-operator"
+	STANOperatorName string = "nats-streaming-operator"
+)


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/siddhi-operator/issues/130

## Goals
Provide a comprehensive error handling mechanism when NATS doesn’t available in the distributed mode of the Siddhi operator.

## Approach
When the user does not install the NATS in the K8s cluster and trying to do the automatic NATS creation, this shows error messages in `SiddhiProcess` and in the operator logs.

To solve that issue user has to do followings:
1. Install [NATS operator](https://github.com/nats-io/nats-operator/releases) and [NATS streaming operator](https://github.com/nats-io/nats-streaming-operator/releases)
1. Again redeploy the Siddhi operator.

## Test environment
minikube version: v1.4.0